### PR TITLE
Add undo highlight option to PDF reader

### DIFF
--- a/src/app/api/highlights/[id]/route.test.ts
+++ b/src/app/api/highlights/[id]/route.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { DELETE } from "./route";
+import type { NextRequest } from "next/server";
+
+function makeSupabaseMock(opts: {
+  user: { id: string } | null;
+  deleteError?: { message: string } | null;
+}) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: opts.user } }),
+    },
+    from: vi.fn().mockReturnValue({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: opts.deleteError ?? null }),
+        }),
+      }),
+    }),
+  };
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+const { createServerSupabaseClient } = await import("@/lib/supabase/server");
+
+describe("DELETE /api/highlights/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns 401 when user is not authenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeSupabaseMock({ user: null }) as never
+    );
+
+    const res = await DELETE(null as unknown as NextRequest, {
+      params: Promise.resolve({ id: "hl-1" }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Authentication required");
+  });
+
+  test("deletes highlight and returns success for authenticated user", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeSupabaseMock({ user: { id: "user-1" } }) as never
+    );
+
+    const res = await DELETE(null as unknown as NextRequest, {
+      params: Promise.resolve({ id: "hl-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  test("returns 500 when database error occurs", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeSupabaseMock({
+        user: { id: "user-1" },
+        deleteError: { message: "DB connection failed" },
+      }) as never
+    );
+
+    const res = await DELETE(null as unknown as NextRequest, {
+      params: Promise.resolve({ id: "hl-1" }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("DB connection failed");
+  });
+
+  test("calls supabase delete with correct user_id and highlight id", async () => {
+    const supabaseMock = makeSupabaseMock({ user: { id: "user-42" } });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(supabaseMock as never);
+
+    await DELETE(null as unknown as NextRequest, {
+      params: Promise.resolve({ id: "highlight-99" }),
+    });
+
+    const fromChain = supabaseMock.from("user_pdf_highlights");
+    const deleteChain = fromChain.delete();
+    expect(deleteChain.eq).toHaveBeenCalledWith("user_id", "user-42");
+    expect(deleteChain.eq("user_id", "user-42").eq).toHaveBeenCalledWith("id", "highlight-99");
+  });
+});

--- a/src/app/api/highlights/[id]/route.test.ts
+++ b/src/app/api/highlights/[id]/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let mockUser: { id: string } | null = { id: "user-123" };
+let mockDeleteError: { message: string } | null = null;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: () =>
+    Promise.resolve({
+      auth: {
+        getUser: () => Promise.resolve({ data: { user: mockUser } }),
+      },
+      from: () => ({
+        delete: () => ({
+          eq: () => ({
+            eq: () => Promise.resolve({ error: mockDeleteError }),
+          }),
+        }),
+      }),
+    }),
+}));
+
+import { DELETE } from "./route";
+import { NextRequest } from "next/server";
+
+const VALID_UUID = "123e4567-e89b-12d3-a456-426614174000";
+
+function makeRequest(id: string) {
+  return new NextRequest(`http://localhost/api/highlights/${id}`, { method: "DELETE" });
+}
+
+describe("DELETE /api/highlights/[id]", () => {
+  beforeEach(() => {
+    mockUser = { id: "user-123" };
+    mockDeleteError = null;
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockUser = null;
+    const res = await DELETE(makeRequest(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Authentication required");
+  });
+
+  it("returns 400 for invalid (non-UUID) id", async () => {
+    const res = await DELETE(makeRequest("not-a-uuid"), {
+      params: Promise.resolve({ id: "not-a-uuid" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid highlight id");
+  });
+
+  it("deletes highlight and returns success for valid UUID", async () => {
+    const res = await DELETE(makeRequest(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 500 when the database returns an error", async () => {
+    mockDeleteError = { message: "DB constraint violation" };
+    const res = await DELETE(makeRequest(VALID_UUID), {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("DB constraint violation");
+  });
+});

--- a/src/app/api/highlights/[id]/route.ts
+++ b/src/app/api/highlights/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid highlight id" }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from("user_pdf_highlights")
+    .delete()
+    .eq("user_id", user.id)
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/highlights/[id]/route.ts
+++ b/src/app/api/highlights/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  if (!id) {
+    return NextResponse.json({ error: "id required" }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from("user_pdf_highlights")
+    .delete()
+    .eq("user_id", user.id)
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/HighlightContextMenu.tsx
+++ b/src/components/HighlightContextMenu.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Trash2 } from "lucide-react";
+
+interface HighlightContextMenuProps {
+  x: number;
+  y: number;
+  highlightId: string;
+  onRemove: (id: string) => void;
+  onClose: () => void;
+}
+
+export function HighlightContextMenu({
+  x,
+  y,
+  highlightId,
+  onRemove,
+  onClose,
+}: HighlightContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Highlight options"
+      className="fixed z-50 rounded-lg border border-ivory-dark bg-white py-1 shadow-lg"
+      style={{ left: x, top: y }}
+    >
+      <button
+        role="menuitem"
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-navy hover:bg-coral/5 hover:text-coral transition-colors"
+        onClick={() => {
+          onRemove(highlightId);
+          onClose();
+        }}
+      >
+        <Trash2 size={14} />
+        Remove Highlight
+      </button>
+    </div>
+  );
+}

--- a/src/components/pdf/HighlightContextMenu.test.tsx
+++ b/src/components/pdf/HighlightContextMenu.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { HighlightContextMenu } from "./HighlightContextMenu";
+
+describe("HighlightContextMenu", () => {
+  afterEach(() => cleanup());
+
+  test("renders menu with Remove Highlight option", () => {
+    render(
+      <HighlightContextMenu x={100} y={200} onRemove={vi.fn()} onClose={vi.fn()} />
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /remove highlight/i })
+    ).toBeInTheDocument();
+  });
+
+  test("calls onRemove and onClose when Remove Highlight is clicked", () => {
+    const onRemove = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <HighlightContextMenu x={100} y={200} onRemove={onRemove} onClose={onClose} />
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /remove highlight/i }));
+
+    expect(onRemove).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("calls onClose when Escape key is pressed", () => {
+    const onClose = vi.fn();
+
+    render(
+      <HighlightContextMenu x={100} y={200} onRemove={vi.fn()} onClose={onClose} />
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("calls onClose when clicking outside the menu", () => {
+    const onClose = vi.fn();
+
+    render(
+      <HighlightContextMenu x={100} y={200} onRemove={vi.fn()} onClose={onClose} />
+    );
+
+    fireEvent.mouseDown(document.body);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("does not call onClose when clicking inside the menu", () => {
+    const onClose = vi.fn();
+
+    render(
+      <HighlightContextMenu x={100} y={200} onRemove={vi.fn()} onClose={onClose} />
+    );
+
+    const menu = screen.getByRole("menu");
+    fireEvent.mouseDown(menu);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test("is positioned at the specified x and y coordinates", () => {
+    render(
+      <HighlightContextMenu x={150} y={250} onRemove={vi.fn()} onClose={vi.fn()} />
+    );
+
+    const menu = screen.getByRole("menu");
+    expect(menu.style.top).toBe("250px");
+    expect(menu.style.left).toBe("150px");
+    expect(menu.style.position).toBe("fixed");
+  });
+});

--- a/src/components/pdf/HighlightContextMenu.tsx
+++ b/src/components/pdf/HighlightContextMenu.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface HighlightContextMenuProps {
+  x: number;
+  y: number;
+  onRemove: () => void;
+  onClose: () => void;
+}
+
+export function HighlightContextMenu({
+  x,
+  y,
+  onRemove,
+  onClose,
+}: HighlightContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      data-testid="highlight-context-menu"
+      style={{ position: "fixed", top: y, left: x, zIndex: 9999 }}
+      className="min-w-[160px] rounded-lg border border-ivory-dark bg-white py-1 shadow-lg"
+    >
+      <button
+        role="menuitem"
+        type="button"
+        className="w-full px-4 py-2 text-left text-sm text-coral transition-colors hover:bg-coral/5"
+        onClick={() => {
+          onRemove();
+          onClose();
+        }}
+      >
+        Remove Highlight
+      </button>
+    </div>
+  );
+}

--- a/src/components/pdf/highlight-context-menu.tsx
+++ b/src/components/pdf/highlight-context-menu.tsx
@@ -51,7 +51,7 @@ export function HighlightContextMenu({
       <button
         role="menuitem"
         type="button"
-        className="flex w-full items-center gap-2 px-4 py-2 text-sm text-coral hover:bg-coral/5"
+        className="flex w-full items-center gap-2 px-4 py-2 text-sm text-coral transition-colors hover:bg-coral/5"
         onClick={() => {
           onRemove(highlightId);
           onClose();

--- a/src/components/pdf/highlight-context-menu.tsx
+++ b/src/components/pdf/highlight-context-menu.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Trash2 } from "lucide-react";
+
+interface HighlightContextMenuProps {
+  x: number;
+  y: number;
+  highlightId: string;
+  onRemove: (id: string) => void;
+  onClose: () => void;
+}
+
+export function HighlightContextMenu({
+  x,
+  y,
+  highlightId,
+  onRemove,
+  onClose,
+}: HighlightContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Highlight options"
+      data-testid="highlight-context-menu"
+      className="fixed z-50 min-w-[160px] rounded-lg border border-ivory-dark bg-white py-1 shadow-lg"
+      style={{ left: x, top: y }}
+    >
+      <button
+        role="menuitem"
+        type="button"
+        className="flex w-full items-center gap-2 px-4 py-2 text-sm text-coral hover:bg-coral/5"
+        onClick={() => {
+          onRemove(highlightId);
+          onClose();
+        }}
+      >
+        <Trash2 size={14} />
+        Remove Highlight
+      </button>
+    </div>
+  );
+}

--- a/src/components/pdf/pdf-reader.test.tsx
+++ b/src/components/pdf/pdf-reader.test.tsx
@@ -193,4 +193,148 @@ describe("PdfReader", () => {
 
     expect(onDeleteHighlight).toHaveBeenCalledWith("hl-1");
   });
+
+  test("shows context menu when right-clicking a highlight in non-highlight mode", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const buttons = await screen.findAllByRole("button", {
+      name: /remove highlight: saved highlight/i,
+    });
+
+    fireEvent.contextMenu(buttons[0]);
+
+    expect(await screen.findByTestId("highlight-context-menu")).toBeInTheDocument();
+  });
+
+  test("clicking Remove Highlight in context menu calls onDeleteHighlight", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const buttons = await screen.findAllByRole("button", {
+      name: /remove highlight: saved highlight/i,
+    });
+
+    fireEvent.contextMenu(buttons[0]);
+
+    const removeMenuItem = await screen.findByRole("menuitem", {
+      name: /remove highlight/i,
+    });
+    fireEvent.click(removeMenuItem);
+
+    expect(onDeleteHighlight).toHaveBeenCalledWith("hl-1");
+  });
+
+  test("Delete key on focused highlight calls onDeleteHighlight", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const buttons = await screen.findAllByRole("button", {
+      name: /remove highlight: saved highlight/i,
+    });
+
+    fireEvent.keyDown(buttons[0], { key: "Delete" });
+
+    expect(onDeleteHighlight).toHaveBeenCalledWith("hl-1");
+  });
+
+  test("context menu does not appear when right-clicking on non-highlight area", async () => {
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={[]}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+      />
+    );
+
+    await screen.findByTestId("mock-document");
+    fireEvent.contextMenu(screen.getByTestId("mock-document"));
+
+    expect(screen.queryByTestId("highlight-context-menu")).not.toBeInTheDocument();
+  });
+
+  test("highlight buttons include hover ring classes for visual feedback", async () => {
+    const onDeleteHighlight = vi.fn();
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const buttons = await screen.findAllByRole("button", {
+      name: /remove highlight/i,
+    });
+
+    expect(buttons[0].className).toContain("hover:ring-1");
+    expect(buttons[0].className).toContain("hover:ring-coral/50");
+  });
 });

--- a/src/components/pdf/pdf-reader.test.tsx
+++ b/src/components/pdf/pdf-reader.test.tsx
@@ -161,7 +161,7 @@ describe("PdfReader", () => {
     expect(selection.removeAllRanges).toHaveBeenCalled();
   });
 
-  test("renders saved PDF highlights as removable controls in PDF view", async () => {
+  test("renders saved PDF highlights as interactive buttons when onDeleteHighlight is provided", async () => {
     const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
     const highlights: PdfHighlight[] = [
       {
@@ -175,22 +175,301 @@ describe("PdfReader", () => {
 
     render(
       <PdfReader
-        {...({
-          url: "https://example.com/mock.pdf",
-          highlights,
-          highlightMode: false,
-          onSaveHighlight: vi.fn(),
-          onDeleteHighlight,
-        } as never)}
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
       />
     );
 
-    const deleteButtons = await screen.findAllByRole("button", {
+    // Highlight is rendered as an accessible button
+    const hlBtn = await screen.findByRole("button", {
+      name: /remove highlight: saved highlight/i,
+    });
+    expect(hlBtn).toBeInTheDocument();
+
+    // Clicking selects the highlight — does NOT immediately delete
+    fireEvent.click(hlBtn);
+    expect(onDeleteHighlight).not.toHaveBeenCalled();
+  });
+
+  test("right-clicking a highlight shows the context menu with Remove Highlight option", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const hlBtn = await screen.findByRole("button", {
       name: /remove highlight: saved highlight/i,
     });
 
-    fireEvent.click(deleteButtons[0]);
+    fireEvent.contextMenu(hlBtn);
+
+    expect(screen.getByTestId("highlight-context-menu")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /remove highlight/i })).toBeInTheDocument();
+  });
+
+  test("clicking Remove Highlight in the context menu calls onDeleteHighlight", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const hlBtn = await screen.findByRole("button", {
+      name: /remove highlight: saved highlight/i,
+    });
+
+    fireEvent.contextMenu(hlBtn);
+    fireEvent.click(screen.getByRole("menuitem", { name: /remove highlight/i }));
 
     expect(onDeleteHighlight).toHaveBeenCalledWith("hl-1");
+  });
+
+  test("pressing Delete key on a focused highlight calls onDeleteHighlight", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-4",
+        page_number: 1,
+        color: "#E91E63",
+        text_content: "Keyboard delete highlight",
+        rects: [{ x: 0.3, y: 0.3, width: 0.3, height: 0.02 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const highlightButton = await screen.findByRole("button", {
+      name: /remove highlight: keyboard delete highlight/i,
+    });
+
+    // Delete key pressed directly on the focused highlight button
+    fireEvent.keyDown(highlightButton, { key: "Delete" });
+
+    expect(onDeleteHighlight).toHaveBeenCalledWith("hl-4");
+  });
+
+  test("pressing Delete key removes the click-selected highlight", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const hlBtn = await screen.findByRole("button", {
+      name: /remove highlight: saved highlight/i,
+    });
+
+    // Click to select the highlight, then press Delete at the document level
+    fireEvent.click(hlBtn);
+    fireEvent.keyDown(document, { key: "Delete" });
+
+    expect(onDeleteHighlight).toHaveBeenCalledWith("hl-1");
+  });
+
+  test("context menu does not appear when right-clicking in highlight mode", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-5",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Highlight mode test",
+        rects: [{ x: 0.1, y: 0.1, width: 0.3, height: 0.02 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={true}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    await screen.findByTestId("mock-page-1");
+
+    const highlightButtons = screen.queryAllByRole("button", {
+      name: /remove highlight/i,
+    });
+
+    if (highlightButtons.length > 0) {
+      fireEvent.contextMenu(highlightButtons[0]);
+    }
+
+    expect(screen.queryByTestId("highlight-context-menu")).not.toBeInTheDocument();
+  });
+
+  test("context menu does not appear when right-clicking outside highlights", async () => {
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={[]}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={vi.fn()}
+      />
+    );
+
+    await screen.findByTestId("mock-page-1");
+
+    fireEvent.contextMenu(document.body);
+
+    expect(screen.queryByTestId("highlight-context-menu")).not.toBeInTheDocument();
+  });
+
+  test("highlight buttons have hover and focus feedback classes when removable", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-6",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Hover feedback",
+        rects: [{ x: 0.1, y: 0.1, width: 0.3, height: 0.02 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const highlightButton = await screen.findByRole("button", {
+      name: /remove highlight: hover feedback/i,
+    });
+
+    expect(highlightButton.className).toContain("hover:ring-1");
+    expect(highlightButton.className).toContain("hover:ring-coral");
+    expect(highlightButton.className).toContain("cursor-pointer");
+  });
+
+  test("context menu closes when Escape is pressed", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-7",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Escape test",
+        rects: [{ x: 0.1, y: 0.1, width: 0.3, height: 0.02 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const highlightButton = await screen.findByRole("button", {
+      name: /remove highlight: escape test/i,
+    });
+
+    fireEvent.contextMenu(highlightButton);
+    expect(screen.getByTestId("highlight-context-menu")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("highlight-context-menu")).not.toBeInTheDocument()
+    );
+  });
+
+  test("Delete key does not fire when no highlight is selected", async () => {
+    const onDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    await screen.findByRole("button", { name: /remove highlight/i });
+
+    // Press Delete on document without selecting a highlight first
+    fireEvent.keyDown(document, { key: "Delete" });
+
+    expect(onDeleteHighlight).not.toHaveBeenCalled();
   });
 });

--- a/src/components/pdf/pdf-reader.test.tsx
+++ b/src/components/pdf/pdf-reader.test.tsx
@@ -472,4 +472,41 @@ describe("PdfReader", () => {
 
     expect(onDeleteHighlight).not.toHaveBeenCalled();
   });
+
+  test("does not crash when highlight removal throws an error", async () => {
+    const onDeleteHighlight = vi.fn().mockRejectedValue(new Error("Network error"));
+    const highlights: PdfHighlight[] = [
+      {
+        id: "hl-1",
+        page_number: 1,
+        color: "#FFEB3B",
+        text_content: "Saved highlight",
+        rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+      },
+    ];
+
+    render(
+      <PdfReader
+        url="https://example.com/mock.pdf"
+        highlights={highlights}
+        highlightMode={false}
+        onSaveHighlight={vi.fn()}
+        onDeleteHighlight={onDeleteHighlight}
+      />
+    );
+
+    const hlBtn = await screen.findByRole("button", {
+      name: /remove highlight: saved highlight/i,
+    });
+
+    fireEvent.contextMenu(hlBtn);
+
+    const removeMenuItem = screen.getByRole("menuitem", { name: /remove highlight/i });
+
+    // Should not throw/crash even when the handler rejects
+    await expect(async () => {
+      fireEvent.click(removeMenuItem);
+      await waitFor(() => expect(onDeleteHighlight).toHaveBeenCalled());
+    }).not.toThrow();
+  });
 });

--- a/src/components/pdf/pdf-reader.tsx
+++ b/src/components/pdf/pdf-reader.tsx
@@ -6,6 +6,7 @@ import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 import { Loader2 } from "lucide-react";
 import { type PdfHighlightRect } from "./highlight-types";
+import { HighlightContextMenu } from "./HighlightContextMenu";
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/build/pdf.worker.min.mjs",
@@ -65,6 +66,12 @@ export function PdfReader({
   const [pageWidth, setPageWidth] = useState(900);
   const [loadingError, setLoadingError] = useState<string | null>(null);
   const [selectionWarning, setSelectionWarning] = useState<string | null>(null);
+  const [selectedHighlightId, setSelectedHighlightId] = useState<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    highlightId: string;
+  } | null>(null);
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -159,7 +166,20 @@ export function PdfReader({
   }
 
   return (
-    <div
+    <>
+      {contextMenu && (
+        <HighlightContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onRemove={() => {
+            if (onDeleteHighlight) {
+              void onDeleteHighlight(contextMenu.highlightId);
+            }
+          }}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+      <div
       ref={containerRef}
       className="flex-1 overflow-auto bg-ivory-dark/50 p-4 md:p-8"
       onMouseUp={() => {
@@ -216,7 +236,7 @@ export function PdfReader({
                       <button
                         key={`${highlight.id}-${rectIndex}`}
                         type="button"
-                        className={`absolute appearance-none rounded-[2px] border-0 p-0 transition-all ${onDeleteHighlight && !highlightMode ? "pointer-events-auto cursor-pointer hover:ring-1 hover:ring-coral/50" : ""}`}
+                        className={`absolute appearance-none rounded-[2px] border-0 p-0 transition-all ${onDeleteHighlight && !highlightMode ? `pointer-events-auto cursor-pointer hover:ring-1 hover:ring-coral/50${selectedHighlightId === highlight.id ? " ring-1 ring-coral/70" : ""}` : ""}`}
                         style={{
                           left: `${rect.x * 100}%`,
                           top: `${rect.y * 100}%`,
@@ -234,8 +254,34 @@ export function PdfReader({
                           if (!onDeleteHighlight || highlightMode) {
                             return;
                           }
-
+                          setSelectedHighlightId(highlight.id);
                           void onDeleteHighlight(highlight.id);
+                        }}
+                        onFocus={() => {
+                          if (!highlightMode) {
+                            setSelectedHighlightId(highlight.id);
+                          }
+                        }}
+                        onBlur={() => setSelectedHighlightId(null)}
+                        onContextMenu={(e) => {
+                          if (!onDeleteHighlight || highlightMode) {
+                            return;
+                          }
+                          e.preventDefault();
+                          setContextMenu({
+                            x: e.clientX,
+                            y: e.clientY,
+                            highlightId: highlight.id,
+                          });
+                        }}
+                        onKeyDown={(e) => {
+                          if (
+                            e.key === "Delete" &&
+                            onDeleteHighlight &&
+                            !highlightMode
+                          ) {
+                            void onDeleteHighlight(highlight.id);
+                          }
                         }}
                       />
                     ))
@@ -247,5 +293,6 @@ export function PdfReader({
         </Document>
       </div>
     </div>
+    </>
   );
 }

--- a/src/components/pdf/pdf-reader.tsx
+++ b/src/components/pdf/pdf-reader.tsx
@@ -297,7 +297,15 @@ export function PdfReader({
             x={contextMenu.x}
             y={contextMenu.y}
             highlightId={contextMenu.highlightId}
-            onRemove={(id) => { void onDeleteHighlight(id); }}
+            onRemove={(id) => {
+              void (async () => {
+                try {
+                  await onDeleteHighlight(id);
+                } catch {
+                  // Removal failed; highlight stays visible
+                }
+              })();
+            }}
             onClose={() => setContextMenu(null)}
           />,
           document.body

--- a/src/components/pdf/pdf-reader.tsx
+++ b/src/components/pdf/pdf-reader.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 import { Loader2 } from "lucide-react";
 import { type PdfHighlightRect } from "./highlight-types";
+import { HighlightContextMenu } from "./highlight-context-menu";
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/build/pdf.worker.min.mjs",
@@ -65,6 +67,8 @@ export function PdfReader({
   const [pageWidth, setPageWidth] = useState(900);
   const [loadingError, setLoadingError] = useState<string | null>(null);
   const [selectionWarning, setSelectionWarning] = useState<string | null>(null);
+  const [selectedHighlightId, setSelectedHighlightId] = useState<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; highlightId: string } | null>(null);
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -83,6 +87,24 @@ export function PdfReader({
     observer.observe(node);
     return () => observer.disconnect();
   }, []);
+
+  // Handle Delete key for click-selected highlights, and Escape to dismiss
+  useEffect(() => {
+    if (!onDeleteHighlight) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Delete" && selectedHighlightId && !highlightMode) {
+        void onDeleteHighlight(selectedHighlightId);
+        setSelectedHighlightId(null);
+      } else if (e.key === "Escape") {
+        setContextMenu(null);
+        setSelectedHighlightId(null);
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [selectedHighlightId, onDeleteHighlight, highlightMode]);
 
   const highlightsByPage = useMemo(() => {
     const grouped = new Map<number, PdfHighlight[]>();
@@ -212,33 +234,55 @@ export function PdfReader({
 
                 <div className="pointer-events-none absolute inset-0">
                   {pageHighlights.map((highlight) =>
-                    highlight.rects.map((rect, rectIndex) => (
-                      <button
-                        key={`${highlight.id}-${rectIndex}`}
-                        type="button"
-                        className={`absolute appearance-none rounded-[2px] border-0 p-0 transition-all ${onDeleteHighlight && !highlightMode ? "pointer-events-auto cursor-pointer hover:ring-1 hover:ring-coral/50" : ""}`}
-                        style={{
-                          left: `${rect.x * 100}%`,
-                          top: `${rect.y * 100}%`,
-                          width: `${rect.width * 100}%`,
-                          height: `${rect.height * 100}%`,
-                          backgroundColor: `${highlight.color}66`,
-                        }}
-                        title={
-                          onDeleteHighlight && !highlightMode
-                            ? `Remove highlight: ${highlight.text_content || "Saved highlight"}`
-                            : highlight.text_content || "Saved highlight"
-                        }
-                        aria-label={`Remove highlight: ${highlight.text_content || "Saved highlight"}`}
-                        onClick={() => {
-                          if (!onDeleteHighlight || highlightMode) {
-                            return;
+                    highlight.rects.map((rect, rectIndex) => {
+                      const isSelected = selectedHighlightId === highlight.id;
+                      const isInteractive = !!onDeleteHighlight && !highlightMode;
+                      return (
+                        <button
+                          key={`${highlight.id}-${rectIndex}`}
+                          type="button"
+                          tabIndex={isInteractive ? 0 : -1}
+                          className={`absolute appearance-none rounded-[2px] border-0 p-0 transition-all ${
+                            isInteractive
+                              ? `pointer-events-auto cursor-pointer hover:ring-1 hover:ring-coral/50 hover:brightness-90 focus:outline-none focus:ring-2 focus:ring-coral focus:ring-offset-1 ${isSelected ? "ring-2 ring-coral" : ""}`
+                              : ""
+                          }`}
+                          style={{
+                            left: `${rect.x * 100}%`,
+                            top: `${rect.y * 100}%`,
+                            width: `${rect.width * 100}%`,
+                            height: `${rect.height * 100}%`,
+                            backgroundColor: `${highlight.color}66`,
+                          }}
+                          title={
+                            isInteractive
+                              ? `Remove highlight: ${highlight.text_content || "Saved highlight"}`
+                              : highlight.text_content || "Saved highlight"
                           }
-
-                          void onDeleteHighlight(highlight.id);
-                        }}
-                      />
-                    ))
+                          aria-label={`Remove highlight: ${highlight.text_content || "Saved highlight"}`}
+                          onClick={() => {
+                            if (!isInteractive) return;
+                            setSelectedHighlightId(
+                              selectedHighlightId === highlight.id ? null : highlight.id
+                            );
+                          }}
+                          onContextMenu={(e) => {
+                            if (!isInteractive) return;
+                            e.preventDefault();
+                            setContextMenu({ x: e.clientX, y: e.clientY, highlightId: highlight.id });
+                          }}
+                          onKeyDown={(e) => {
+                            if (!isInteractive) return;
+                            if (e.key === "Delete" || e.key === "Backspace") {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              void onDeleteHighlight!(highlight.id);
+                              setSelectedHighlightId(null);
+                            }
+                          }}
+                        />
+                      );
+                    })
                   )}
                 </div>
               </div>
@@ -246,6 +290,18 @@ export function PdfReader({
           })}
         </Document>
       </div>
+
+      {contextMenu && onDeleteHighlight &&
+        createPortal(
+          <HighlightContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            highlightId={contextMenu.highlightId}
+            onRemove={(id) => { void onDeleteHighlight(id); }}
+            onClose={() => setContextMenu(null)}
+          />,
+          document.body
+        )}
     </div>
   );
 }

--- a/src/hooks/use-highlights.ts
+++ b/src/hooks/use-highlights.ts
@@ -1,0 +1,12 @@
+import { useCallback } from "react";
+import { removeHighlight } from "@/lib/highlights";
+
+export function useHighlightDelete(onDeleted: (id: string) => void) {
+  return useCallback(
+    async (id: string) => {
+      await removeHighlight(id);
+      onDeleted(id);
+    },
+    [onDeleted]
+  );
+}

--- a/src/hooks/useHighlights.test.ts
+++ b/src/hooks/useHighlights.test.ts
@@ -1,0 +1,142 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/highlights.js", () => ({
+  fetchHighlights: vi.fn(),
+  deleteHighlightById: vi.fn(),
+}));
+
+// Import after mocking to get the TS version (docId-based API)
+import { useHighlights } from "./useHighlights.ts";
+import { fetchHighlights, deleteHighlightById } from "@/lib/highlights.js";
+
+const MOCK_HIGHLIGHTS = [
+  {
+    id: "hl-1",
+    document_id: "doc-1",
+    page_number: 1,
+    color: "#FFEB3B",
+    text_content: "First highlight",
+    rects: [{ x: 0.1, y: 0.2, width: 0.4, height: 0.03 }],
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "hl-2",
+    document_id: "doc-1",
+    page_number: 2,
+    color: "#4CAF50",
+    text_content: "Second highlight",
+    rects: [{ x: 0.2, y: 0.3, width: 0.3, height: 0.02 }],
+    created_at: "2026-01-02T00:00:00Z",
+  },
+];
+
+describe("useHighlights", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("load() fetches highlights and populates the highlights list", async () => {
+    vi.mocked(fetchHighlights).mockResolvedValue(MOCK_HIGHLIGHTS);
+
+    const { result } = renderHook(() => useHighlights("doc-1"));
+
+    expect(result.current.highlights).toEqual([]);
+    expect(result.current.loading).toBe(false);
+
+    act(() => {
+      void result.current.load();
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.highlights).toEqual(MOCK_HIGHLIGHTS);
+    expect(result.current.error).toBeNull();
+    expect(fetchHighlights).toHaveBeenCalledWith("doc-1");
+  });
+
+  test("load() sets error state when fetchHighlights throws", async () => {
+    vi.mocked(fetchHighlights).mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(() => useHighlights("doc-1"));
+
+    await act(async () => {
+      await result.current.load();
+    });
+
+    expect(result.current.error).toBe("Network error");
+    expect(result.current.highlights).toEqual([]);
+  });
+
+  test("removeHighlight() deletes a highlight from the list and calls the API", async () => {
+    vi.mocked(fetchHighlights).mockResolvedValue(MOCK_HIGHLIGHTS);
+    vi.mocked(deleteHighlightById).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useHighlights("doc-1"));
+
+    await act(async () => {
+      await result.current.load();
+    });
+
+    expect(result.current.highlights).toHaveLength(2);
+
+    await act(async () => {
+      await result.current.removeHighlight("hl-1");
+    });
+
+    expect(deleteHighlightById).toHaveBeenCalledWith("hl-1");
+    expect(result.current.highlights).toHaveLength(1);
+    expect(result.current.highlights[0].id).toBe("hl-2");
+  });
+
+  test("removeHighlight() sets error state and re-throws when API fails", async () => {
+    vi.mocked(fetchHighlights).mockResolvedValue(MOCK_HIGHLIGHTS);
+    vi.mocked(deleteHighlightById).mockRejectedValue(new Error("DB error"));
+
+    const { result } = renderHook(() => useHighlights("doc-1"));
+
+    await act(async () => {
+      await result.current.load();
+    });
+
+    let thrownError: Error | null = null;
+    await act(async () => {
+      try {
+        await result.current.removeHighlight("hl-1");
+      } catch (err) {
+        thrownError = err as Error;
+      }
+    });
+
+    expect(thrownError).not.toBeNull();
+    expect(thrownError!.message).toBe("DB error");
+    expect(result.current.error).toBe("DB error");
+    // List unchanged since delete failed
+    expect(result.current.highlights).toHaveLength(2);
+  });
+
+  test("addHighlight() appends a highlight without an API call", () => {
+    const { result } = renderHook(() => useHighlights("doc-1"));
+
+    const newHighlight = {
+      id: "hl-new",
+      document_id: "doc-1",
+      page_number: 3,
+      color: "#2196F3",
+      text_content: "New highlight",
+      rects: [],
+      created_at: "2026-01-03T00:00:00Z",
+    };
+
+    act(() => {
+      result.current.addHighlight(newHighlight);
+    });
+
+    expect(result.current.highlights).toHaveLength(1);
+    expect(result.current.highlights[0]).toEqual(newHighlight);
+    expect(fetchHighlights).not.toHaveBeenCalled();
+    expect(deleteHighlightById).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useHighlights.ts
+++ b/src/hooks/useHighlights.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+import { removeHighlight } from "@/lib/highlights";
+
+export interface HighlightBase {
+  id: string;
+}
+
+/**
+ * Hook for managing a list of highlights with delete support.
+ */
+export function useHighlights<T extends HighlightBase>(initial: T[] = []) {
+  const [highlights, setHighlights] = useState<T[]>(initial);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  const deleteHighlight = useCallback(async (id: string) => {
+    try {
+      await removeHighlight(id);
+      setHighlights((prev) => prev.filter((h) => h.id !== id));
+      setRemoveError(null);
+    } catch (err) {
+      setRemoveError(
+        err instanceof Error ? err.message : "Failed to remove highlight"
+      );
+    }
+  }, []);
+
+  return { highlights, setHighlights, deleteHighlight, removeError };
+}

--- a/src/hooks/useHighlights.ts
+++ b/src/hooks/useHighlights.ts
@@ -1,0 +1,51 @@
+import { useState, useCallback } from "react";
+import { deleteHighlightById, fetchHighlights } from "@/lib/highlights.js";
+
+export interface HighlightRecord {
+  id: string;
+  document_id: string;
+  page_number: number;
+  color: string;
+  text_content: string | null;
+  rects: unknown;
+  created_at: string;
+}
+
+export function useHighlights(docId: string) {
+  const [highlights, setHighlights] = useState<HighlightRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchHighlights(docId);
+      setHighlights(data as HighlightRecord[]);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load highlights"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [docId]);
+
+  const removeHighlight = useCallback(async (id: string) => {
+    try {
+      await deleteHighlightById(id);
+      setHighlights((prev) => prev.filter((h) => h.id !== id));
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to delete highlight"
+      );
+      throw err;
+    }
+  }, []);
+
+  const addHighlight = useCallback((highlight: HighlightRecord) => {
+    setHighlights((prev) => [...prev, highlight]);
+  }, []);
+
+  return { highlights, loading, error, load, removeHighlight, addHighlight };
+}

--- a/src/lib/highlights.js
+++ b/src/lib/highlights.js
@@ -1,0 +1,31 @@
+/**
+ * Client-side utilities for highlight API calls.
+ */
+
+/**
+ * Fetch all highlights for a document.
+ * @param {string} docId
+ * @returns {Promise<object[]>}
+ */
+export async function fetchHighlights(docId) {
+  const res = await fetch(`/api/highlights?docId=${encodeURIComponent(docId)}`);
+  if (!res.ok) {
+    throw new Error("Failed to fetch highlights");
+  }
+  return res.json();
+}
+
+/**
+ * Delete a highlight by ID via the /api/highlights/:id route.
+ * @param {string} id
+ * @returns {Promise<void>}
+ */
+export async function deleteHighlightById(id) {
+  const res = await fetch(`/api/highlights/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error ?? "Failed to delete highlight");
+  }
+}

--- a/src/lib/highlights.test.ts
+++ b/src/lib/highlights.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { removeHighlight } from "./highlights";
+
+describe("removeHighlight", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("calls DELETE /api/highlights/:id", async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+
+    await removeHighlight("hl-123");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/highlights/hl-123", {
+      method: "DELETE",
+    });
+  });
+
+  test("resolves without error on success", async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await expect(removeHighlight("hl-1")).resolves.toBeUndefined();
+  });
+
+  test("throws an error when the response is not ok", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Not found" }),
+    });
+
+    await expect(removeHighlight("hl-1")).rejects.toThrow("Not found");
+  });
+
+  test("throws a generic error when response has no error field", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    });
+
+    await expect(removeHighlight("hl-1")).rejects.toThrow(
+      "Failed to remove highlight"
+    );
+  });
+
+  test("throws an error when json parsing fails", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => {
+        throw new Error("invalid json");
+      },
+    });
+
+    await expect(removeHighlight("hl-1")).rejects.toThrow(
+      "Failed to remove highlight"
+    );
+  });
+});

--- a/src/lib/highlights.ts
+++ b/src/lib/highlights.ts
@@ -1,0 +1,13 @@
+/**
+ * Removes a highlight by ID via the REST API.
+ * Throws an error if the request fails.
+ */
+export async function removeHighlight(id: string): Promise<void> {
+  const res = await fetch(`/api/highlights/${id}`, { method: "DELETE" });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error?: string }).error || "Failed to remove highlight"
+    );
+  }
+}


### PR DESCRIPTION
Closes #8

## Summary

- Added `HighlightContextMenu` component that appears on right-click over any existing highlight
- Right-clicking a highlight shows a context menu with a "Remove Highlight" option
- Pressing the `Delete` key while a highlight button is focused removes the highlight immediately
- Context menu only appears on actual highlights (not on empty areas)
- Existing visual feedback (hover ring) retained for removable highlights
- 6 new tests added covering: context menu display, Remove Highlight click, Delete key shortcut, highlight mode blocking context menu, visual feedback classes, and error handling

## Files Changed

- `src/components/pdf/highlight-context-menu.tsx` — new context menu component
- `src/components/pdf/pdf-reader.tsx` — added `onContextMenu` and `onKeyDown` handlers on highlight buttons
- `src/components/pdf/pdf-reader.test.tsx` — added 6 new tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/msanchezgrice/asoprs/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-click highlights to show a floating "Remove Highlight" menu
  * Client utilities and a hook for loading, saving, and deleting highlights
  * API endpoint for deleting highlights

* **Usability**
  * Selected highlight shows a visual focus state when active
  * Context menu closes when clicking outside; Delete key removes a selected highlight

* **Tests**
  * Added tests covering context menu interactions, Delete-key removal, and API delete flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->